### PR TITLE
Remove eval-when-compile for using cl function

### DIFF
--- a/furl.el
+++ b/furl.el
@@ -35,7 +35,7 @@
 ;;; Code:
 
 (require 'url)
-(eval-when-compile (require 'cl))
+(require 'cl)
 
 (defvar furl-silent nil
   "Whether to retrieve URLs without messaging progress reports.


### PR DESCRIPTION
This package has to load cl.el not only compile time, but also runtime.
Because gensym is a function.
